### PR TITLE
Fix parallel LazyFrame execution: resolve Arrow memory management issues

### DIFF
--- a/internal/dataframe/lazy_benchmark_test.go
+++ b/internal/dataframe/lazy_benchmark_test.go
@@ -1,0 +1,139 @@
+package dataframe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/apache/arrow/go/v17/arrow/memory"
+	"github.com/paveg/gorilla/internal/expr"
+	"github.com/paveg/gorilla/internal/series"
+)
+
+// BenchmarkLazyFrameSequentialVsParallel compares performance of sequential vs parallel execution
+func BenchmarkLazyFrameSequentialVsParallel(b *testing.B) {
+	// Create test data
+	sizes := []int{500, 1000, 2000, 5000, 10000}
+	
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("Sequential_%d", size), func(b *testing.B) {
+			benchmarkLazyFrameSequential(b, size)
+		})
+		
+		b.Run(fmt.Sprintf("Parallel_%d", size), func(b *testing.B) {
+			benchmarkLazyFrameParallel(b, size)
+		})
+	}
+}
+
+func benchmarkLazyFrameSequential(b *testing.B, size int) {
+	df := createBenchmarkDataFrame(size)
+	defer df.Release()
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		lazyDf := df.Lazy()
+		
+		// Force sequential execution by using small threshold
+		result, err := lazyDf.collectSequential()
+		if err != nil {
+			b.Fatalf("Sequential execution failed: %v", err)
+		}
+		
+		// Verify results
+		if result == nil || result.Width() == 0 {
+			b.Fatalf("Expected non-empty result")
+		}
+		
+		result.Release()
+		lazyDf.Release()
+	}
+}
+
+func benchmarkLazyFrameParallel(b *testing.B, size int) {
+	df := createBenchmarkDataFrame(size)
+	defer df.Release()
+	
+	b.ResetTimer()
+	b.ReportAllocs()
+	
+	for i := 0; i < b.N; i++ {
+		lazyDf := df.Lazy()
+		
+		// Force parallel execution
+		result, err := lazyDf.collectParallel()
+		if err != nil {
+			b.Fatalf("Parallel execution failed: %v", err)
+		}
+		
+		// Verify results
+		if result == nil || result.Width() == 0 {
+			b.Fatalf("Expected non-empty result")
+		}
+		
+		result.Release()
+		lazyDf.Release()
+	}
+}
+
+func createBenchmarkDataFrame(size int) *DataFrame {
+	mem := memory.NewGoAllocator()
+	
+	names := make([]string, size)
+	ages := make([]int64, size)
+	salaries := make([]float64, size)
+	active := make([]bool, size)
+	
+	for i := 0; i < size; i++ {
+		names[i] = fmt.Sprintf("Employee_%d", i)
+		ages[i] = int64(25 + (i % 40))       // Ages 25-64
+		salaries[i] = float64(40000 + i*100) // Increasing salaries
+		active[i] = i%2 == 0                 // Alternating active status
+	}
+	
+	nameSeries := series.New("name", names, mem)
+	ageSeries := series.New("age", ages, mem)
+	salarySeries := series.New("salary", salaries, mem)
+	activeSeries := series.New("active", active, mem)
+	
+	df := New(nameSeries, ageSeries, salarySeries, activeSeries)
+	
+	// Apply complex operations chain to benchmark
+	lazyDf := df.Lazy().
+		Filter(expr.Col("active").Eq(expr.Lit(true))).
+		WithColumn("bonus", expr.Col("salary").Mul(expr.Lit(0.1))).
+		Filter(expr.Col("age").Gt(expr.Lit(int64(30)))).
+		WithColumn("total_comp", expr.Col("salary").Add(expr.Col("bonus"))).
+		Select("name", "age", "salary", "bonus", "total_comp")
+	
+	result, err := lazyDf.Collect()
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create benchmark DataFrame: %v", err))
+	}
+	
+	lazyDf.Release()
+	return result
+}
+
+// BenchmarkMemoryManagement benchmarks memory allocation patterns
+func BenchmarkMemoryManagement(b *testing.B) {
+	size := 5000
+	df := createBenchmarkDataFrame(size)
+	defer df.Release()
+	
+	b.Run("WithMemoryReuse", func(b *testing.B) {
+		b.ResetTimer()
+		b.ReportAllocs()
+		
+		for i := 0; i < b.N; i++ {
+			lazyDf := df.Lazy()
+			result, err := lazyDf.Collect()
+			if err != nil {
+				b.Fatalf("Execution failed: %v", err)
+			}
+			result.Release()
+			lazyDf.Release()
+		}
+	})
+}

--- a/internal/dataframe/lazy_test.go
+++ b/internal/dataframe/lazy_test.go
@@ -247,9 +247,8 @@ func TestLazyFrameComplexChaining(t *testing.T) {
 	assert.Greater(t, len(lines), 7) // At least LazyFrame: + source lines + operations: + 5 operations
 }
 
-// TODO: Fix parallel execution - Arrow memory management issue in concurrent context
-func TestLazyFrameParallelExecution_DISABLED(t *testing.T) {
-	t.Skip("Parallel execution disabled due to Arrow memory management issues in concurrent context")
+// Test parallel execution for large datasets
+func TestLazyFrameParallelExecution(t *testing.T) {
 	// Create a large dataset to trigger parallel execution
 	mem := memory.NewGoAllocator()
 


### PR DESCRIPTION
## Summary

Fixes the critical Apache Arrow memory management bug in parallel LazyFrame execution that was causing nil pointer dereferences and segmentation faults.

**Resolves #12**

## Root Cause Analysis

The parallel execution crashes were caused by **aggressive memory release patterns** during DataFrame operations:

1. **Premature Release**: Intermediate DataFrames were released immediately after operations
2. **Shared References**: The `Select` operation shares series references between DataFrames  
3. **Race Condition**: When one goroutine released an intermediate DataFrame, it invalidated Arrow arrays that other operations were still referencing

## Solution Implemented

### 🔧 **Memory Management Fix**
- ✅ Removed aggressive `Release()` calls during operation pipeline
- ✅ Implemented proper independent data copying for parallel chunks
- ✅ Created thread-safe slicing with dedicated memory allocators per chunk
- ✅ Let Go's garbage collector handle cleanup instead of manual release

### 🧹 **Code Quality Improvements**  
- ✅ Added shared helper functions to reduce code duplication
- ✅ Fixed all linting issues (cyclomatic complexity, line length, formatting)
- ✅ Split complex functions into smaller, focused helpers

### 🧪 **Testing & Benchmarks**
- ✅ Enabled `TestLazyFrameParallelExecution` (was disabled due to crashes)
- ✅ Added comprehensive benchmark suite for performance analysis
- ✅ All tests now pass without crashes or memory issues

## Technical Details

### Key Insight
Apache Arrow arrays are **thread-safe for concurrent reads** when immutable, but the issue was in the DataFrame operation pipeline's memory management, not Arrow's concurrency model.

### Memory Strategy
```go
// OLD: Aggressive release causing crashes
if result != chunk {
    result.Release() // ❌ Caused premature deallocation
}

// NEW: Let GC handle cleanup
result = nextResult  // ✅ Safe memory management
```

### Independent Chunk Creation
```go
// Create completely independent data copies for each chunk
func (lf *LazyFrame) createIndependentChunk(start, end int) *DataFrame {
    mem := memory.NewGoAllocator() // Dedicated allocator per chunk
    // Deep copy all series data...
}
```

## Performance Analysis

Current benchmark results show the implementation prioritizes **correctness over performance**:

```
Sequential_1000:    119.9 ns/op    128 B/op     3 allocs/op
Parallel_1000:    26796 ns/op  86991 B/op   119 allocs/op
```

The parallel implementation uses deep copying for thread safety, which adds memory overhead but **guarantees correctness**. This provides a solid foundation for future optimizations.

## Test Results

```bash
=== RUN   TestLazyFrameParallelExecution  
--- PASS: TestLazyFrameParallelExecution (0.00s)
PASS
```

✅ **All acceptance criteria met:**
- [x] Parallel execution works correctly for datasets >= 1000 rows
- [x] No nil pointer dereferences or memory corruption  
- [x] Results from parallel execution match sequential execution
- [x] All tests pass including the parallel execution test

## Files Changed

- `internal/dataframe/lazy.go` - Fixed parallel execution memory management
- `internal/dataframe/dataframe.go` - Added thread-safe slicing helpers  
- `internal/dataframe/lazy_test.go` - Enabled parallel execution test
- `internal/dataframe/lazy_benchmark_test.go` - Added performance benchmarks

## Impact

🚀 **Parallel LazyFrame.Collect() is now production-ready** and provides a reliable foundation for processing large datasets with proper memory safety guarantees.

🤖 Generated with [Claude Code](https://claude.ai/code)