### PR TITLE
fix: improve memory management guidance - prefer defer pattern over MemoryManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,38 @@ To add Gorilla to your project, use `go get`:
 go get github.com/paveg/gorilla
 ```
 
+### Memory Management
+
+Gorilla is built on Apache Arrow, which requires explicit memory management. **We strongly recommend using the `defer` pattern** for most use cases as it provides better readability and prevents memory leaks.
+
+#### ✅ Recommended: Defer Pattern
+
+```go
+// Create resources and immediately defer their cleanup
+mem := memory.NewGoAllocator()
+df := gorilla.NewDataFrame(series1, series2)
+defer df.Release() // ← Clear resource lifecycle
+
+result, err := df.Lazy().Filter(...).Collect()
+defer result.Release() // ← Always clean up results
+```
+
+#### 📋 When to Use MemoryManager
+
+For complex scenarios with many short-lived resources, you can use `MemoryManager`:
+
+```go
+err := gorilla.WithMemoryManager(mem, func(manager *gorilla.MemoryManager) error {
+    // Create multiple temporary resources
+    for i := 0; i < 100; i++ {
+        temp := createTempDataFrame(i)
+        manager.Track(temp) // Bulk cleanup at end
+    }
+    return processData()
+})
+// All tracked resources automatically released
+```
+
 ### Quick Example
 
 Here is a quick example to demonstrate the basic usage of Gorilla.


### PR DESCRIPTION
This PR addresses issue #59 by improving memory management guidance throughout the codebase documentation.

## Summary

Enhanced memory management documentation to prioritize the `defer` pattern for better readability and leak prevention, while keeping `MemoryManager` for appropriate use cases.

## Changes Made

### 📖 README.md Updates
- Added dedicated **Memory Management** section with clear guidance
- Provided side-by-side comparison of defer pattern vs MemoryManager
- Included practical examples showing when to use each approach
- Emphasized defer pattern as the recommended default

### 📚 CLAUDE.md Enhancements  
- Expanded memory management section with comprehensive best practices
- Added detailed code examples demonstrating proper defer usage
- Updated testing patterns to emphasize defer in test cleanup
- Enhanced Common Pitfalls section with memory management guidance
- Clarified when MemoryManager is appropriate vs defer patterns

## Key Benefits

✅ **Better Readability** - Resource lifecycle is explicit at allocation point  
✅ **Leak Prevention** - Harder to forget releases when co-located with allocation  
✅ **Go Idioms** - Follows canonical Go patterns for resource cleanup  
✅ **Developer Experience** - Clearer guidance for new contributors  
✅ **Easier Debugging** - Clear tracking of resource management  

## Pattern Comparison

### ✅ Recommended: Defer Pattern
```go
mem := memory.NewGoAllocator()
df := gorilla.NewDataFrame(series1, series2)
defer df.Release() // ← Clear resource lifecycle
```

### 📋 Alternative: MemoryManager (for bulk operations)
```go
err := gorilla.WithMemoryManager(mem, func(manager *gorilla.MemoryManager) error {
    // Many short-lived resources
    for i := 0; i < 100; i++ {
        temp := createTempDataFrame(i)
        manager.Track(temp) // Bulk cleanup
    }
    return processData()
})
```

## Testing

- ✅ All existing tests pass
- ✅ Documentation-only changes, no functional impact
- ✅ Linting passes

The `defer` pattern is now the recommended approach for most DataFrame operations, while `MemoryManager` remains available for complex scenarios with many short-lived resources.

Closes #59