### PR TITLE
feat: Add support for additional integer types (int16, int8, uint64, uint32, uint16, uint8)

### DIFF
--- a/internal/dataframe/dataframe.go
+++ b/internal/dataframe/dataframe.go
@@ -268,8 +268,24 @@ func createSlicedSeriesFromArray(
 		return createSlicedStringSeries(name, typedArr, start, length, mem)
 	case *array.Int64:
 		return createSlicedInt64Series(name, typedArr, start, length, mem)
+	case *array.Int32:
+		return createSlicedInt32Series(name, typedArr, start, length, mem)
+	case *array.Int16:
+		return createSlicedInt16Series(name, typedArr, start, length, mem)
+	case *array.Int8:
+		return createSlicedInt8Series(name, typedArr, start, length, mem)
+	case *array.Uint64:
+		return createSlicedUint64Series(name, typedArr, start, length, mem)
+	case *array.Uint32:
+		return createSlicedUint32Series(name, typedArr, start, length, mem)
+	case *array.Uint16:
+		return createSlicedUint16Series(name, typedArr, start, length, mem)
+	case *array.Uint8:
+		return createSlicedUint8Series(name, typedArr, start, length, mem)
 	case *array.Float64:
 		return createSlicedFloat64Series(name, typedArr, start, length, mem)
+	case *array.Float32:
+		return createSlicedFloat32Series(name, typedArr, start, length, mem)
 	case *array.Boolean:
 		return createSlicedBoolSeries(name, typedArr, start, length, mem)
 	case *array.Timestamp:
@@ -311,8 +327,48 @@ func createSlicedInt64Series(name string, typedArr *array.Int64, start, length i
 	return createSlicedSeries(name, typedArr, start, length, mem)
 }
 
+// createSlicedInt32Series creates an int32 series slice
+func createSlicedInt32Series(name string, typedArr *array.Int32, start, length int, mem memory.Allocator) ISeries {
+	return createSlicedSeries(name, typedArr, start, length, mem)
+}
+
+// createSlicedInt16Series creates an int16 series slice
+func createSlicedInt16Series(name string, typedArr *array.Int16, start, length int, mem memory.Allocator) ISeries {
+	return createSlicedSeries(name, typedArr, start, length, mem)
+}
+
+// createSlicedInt8Series creates an int8 series slice
+func createSlicedInt8Series(name string, typedArr *array.Int8, start, length int, mem memory.Allocator) ISeries {
+	return createSlicedSeries(name, typedArr, start, length, mem)
+}
+
+// createSlicedUint64Series creates a uint64 series slice
+func createSlicedUint64Series(name string, typedArr *array.Uint64, start, length int, mem memory.Allocator) ISeries {
+	return createSlicedSeries(name, typedArr, start, length, mem)
+}
+
+// createSlicedUint32Series creates a uint32 series slice
+func createSlicedUint32Series(name string, typedArr *array.Uint32, start, length int, mem memory.Allocator) ISeries {
+	return createSlicedSeries(name, typedArr, start, length, mem)
+}
+
+// createSlicedUint16Series creates a uint16 series slice
+func createSlicedUint16Series(name string, typedArr *array.Uint16, start, length int, mem memory.Allocator) ISeries {
+	return createSlicedSeries(name, typedArr, start, length, mem)
+}
+
+// createSlicedUint8Series creates a uint8 series slice
+func createSlicedUint8Series(name string, typedArr *array.Uint8, start, length int, mem memory.Allocator) ISeries {
+	return createSlicedSeries(name, typedArr, start, length, mem)
+}
+
 // createSlicedFloat64Series creates a float64 series slice
 func createSlicedFloat64Series(name string, typedArr *array.Float64, start, length int, mem memory.Allocator) ISeries {
+	return createSlicedSeries(name, typedArr, start, length, mem)
+}
+
+// createSlicedFloat32Series creates a float32 series slice
+func createSlicedFloat32Series(name string, typedArr *array.Float32, start, length int, mem memory.Allocator) ISeries {
 	return createSlicedSeries(name, typedArr, start, length, mem)
 }
 

--- a/internal/dataframe/new_types_test.go
+++ b/internal/dataframe/new_types_test.go
@@ -134,4 +134,50 @@ func TestDataFrameWithNewIntegerTypes(t *testing.T) {
 		expectedTail := []uint8{8, 9, 10}
 		assert.Equal(t, expectedTail, tailValues)
 	})
+
+	t.Run("DataFrame slicing with int32 series", func(t *testing.T) {
+		int32Values := []int32{100, 200, 300, 400, 500}
+		int32Series, err := series.NewSafe("values", int32Values, mem)
+		require.NoError(t, err)
+		defer int32Series.Release()
+
+		df := New(int32Series)
+		defer df.Release()
+
+		// Test slicing
+		sliced := df.Slice(1, 4)
+		defer sliced.Release()
+
+		assert.Equal(t, 3, sliced.Len())
+
+		// Verify sliced values
+		valuesSeries, exists := sliced.Column("values")
+		require.True(t, exists)
+		values := valuesSeries.(*series.Series[int32]).Values()
+		expected := []int32{200, 300, 400}
+		assert.Equal(t, expected, values)
+	})
+
+	t.Run("DataFrame slicing with float32 series", func(t *testing.T) {
+		float32Values := []float32{1.1, 2.2, 3.3, 4.4, 5.5}
+		float32Series, err := series.NewSafe("values", float32Values, mem)
+		require.NoError(t, err)
+		defer float32Series.Release()
+
+		df := New(float32Series)
+		defer df.Release()
+
+		// Test slicing
+		sliced := df.Slice(1, 4)
+		defer sliced.Release()
+
+		assert.Equal(t, 3, sliced.Len())
+
+		// Verify sliced values
+		valuesSeries, exists := sliced.Column("values")
+		require.True(t, exists)
+		values := valuesSeries.(*series.Series[float32]).Values()
+		expected := []float32{2.2, 3.3, 4.4}
+		assert.Equal(t, expected, values)
+	})
 }

--- a/internal/dataframe/new_types_test.go
+++ b/internal/dataframe/new_types_test.go
@@ -1,0 +1,137 @@
+package dataframe
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/paveg/gorilla/internal/series"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDataFrameWithNewIntegerTypes tests DataFrame operations with the new integer types
+func TestDataFrameWithNewIntegerTypes(t *testing.T) {
+	mem := memory.NewGoAllocator()
+
+	t.Run("DataFrame creation with int16 series", func(t *testing.T) {
+		// Create series with new integer types
+		int16Values := []int16{1, 2, 3, 4, 5}
+		int16Series, err := series.NewSafe("int16_col", int16Values, mem)
+		require.NoError(t, err)
+		defer int16Series.Release()
+
+		// Create DataFrame
+		df := New(int16Series)
+		defer df.Release()
+
+		// Test basic operations
+		assert.Equal(t, 5, df.Len())
+		assert.Equal(t, 1, df.Width())
+		assert.Equal(t, []string{"int16_col"}, df.Columns())
+	})
+
+	t.Run("DataFrame creation with uint64 series", func(t *testing.T) {
+		uint64Values := []uint64{1, 2, 3, 4, 5}
+		uint64Series, err := series.NewSafe("uint64_col", uint64Values, mem)
+		require.NoError(t, err)
+		defer uint64Series.Release()
+
+		df := New(uint64Series)
+		defer df.Release()
+
+		assert.Equal(t, 5, df.Len())
+		assert.Equal(t, 1, df.Width())
+		assert.Equal(t, []string{"uint64_col"}, df.Columns())
+	})
+
+	t.Run("DataFrame creation with multiple new integer types", func(t *testing.T) {
+		int8Values := []int8{1, 2, 3}
+		uint32Values := []uint32{10, 20, 30}
+		uint16Values := []uint16{100, 200, 300}
+		uint8Values := []uint8{50, 60, 70}
+
+		int8Series, err := series.NewSafe("int8_col", int8Values, mem)
+		require.NoError(t, err)
+		defer int8Series.Release()
+
+		uint32Series, err := series.NewSafe("uint32_col", uint32Values, mem)
+		require.NoError(t, err)
+		defer uint32Series.Release()
+
+		uint16Series, err := series.NewSafe("uint16_col", uint16Values, mem)
+		require.NoError(t, err)
+		defer uint16Series.Release()
+
+		uint8Series, err := series.NewSafe("uint8_col", uint8Values, mem)
+		require.NoError(t, err)
+		defer uint8Series.Release()
+
+		df := New(int8Series, uint32Series, uint16Series, uint8Series)
+		defer df.Release()
+
+		assert.Equal(t, 3, df.Len())
+		assert.Equal(t, 4, df.Width())
+		expectedCols := []string{"int8_col", "uint16_col", "uint32_col", "uint8_col"}
+		assert.ElementsMatch(t, expectedCols, df.Columns())
+	})
+
+	t.Run("DataFrame slicing with new integer types", func(t *testing.T) {
+		int16Values := []int16{10, 20, 30, 40, 50}
+		int16Series, err := series.NewSafe("values", int16Values, mem)
+		require.NoError(t, err)
+		defer int16Series.Release()
+
+		df := New(int16Series)
+		defer df.Release()
+
+		// Test slicing
+		sliced := df.Slice(1, 4)
+		defer sliced.Release()
+
+		assert.Equal(t, 3, sliced.Len())
+
+		// Verify sliced values
+		valuesSeries, exists := sliced.Column("values")
+		require.True(t, exists)
+		values := valuesSeries.(*series.Series[int16]).Values()
+		expected := []int16{20, 30, 40}
+		assert.Equal(t, expected, values)
+	})
+
+	t.Run("DataFrame with uint8 series", func(t *testing.T) {
+		uint8Values := []uint8{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+		uint8Series, err := series.NewSafe("values", uint8Values, mem)
+		require.NoError(t, err)
+		defer uint8Series.Release()
+
+		df := New(uint8Series)
+		defer df.Release()
+
+		// Test basic properties
+		assert.Equal(t, 10, df.Len())
+		assert.Equal(t, 1, df.Width())
+		assert.Equal(t, []string{"values"}, df.Columns())
+
+		// Test slicing first 3 elements
+		head := df.Slice(0, 3)
+		defer head.Release()
+
+		assert.Equal(t, 3, head.Len())
+		headSeries, exists := head.Column("values")
+		require.True(t, exists)
+		headValues := headSeries.(*series.Series[uint8]).Values()
+		expectedHead := []uint8{1, 2, 3}
+		assert.Equal(t, expectedHead, headValues)
+
+		// Test slicing last 3 elements
+		tail := df.Slice(7, 10)
+		defer tail.Release()
+
+		assert.Equal(t, 3, tail.Len())
+		tailSeries, exists := tail.Column("values")
+		require.True(t, exists)
+		tailValues := tailSeries.(*series.Series[uint8]).Values()
+		expectedTail := []uint8{8, 9, 10}
+		assert.Equal(t, expectedTail, tailValues)
+	})
+}

--- a/internal/series/new_types_test.go
+++ b/internal/series/new_types_test.go
@@ -121,4 +121,52 @@ func TestNewIntegerTypes(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, values, retrievedValues)
 	})
+
+	t.Run("int32 series creation and operations", func(t *testing.T) {
+		values := []int32{100, -200, 300, -400, 500}
+		series, err := NewSafe("test_int32", values, mem)
+		require.NoError(t, err)
+		defer series.Release()
+
+		// Test basic properties
+		assert.Equal(t, "test_int32", series.Name())
+		assert.Equal(t, 5, series.Len())
+		assert.Equal(t, arrow.PrimitiveTypes.Int32, series.DataType())
+
+		// Test value retrieval
+		retrievedValues, err := series.ValuesSafe()
+		require.NoError(t, err)
+		assert.Equal(t, values, retrievedValues)
+
+		// Test individual value access
+		val := series.Value(0)
+		assert.Equal(t, int32(100), val)
+
+		val = series.Value(1)
+		assert.Equal(t, int32(-200), val)
+	})
+
+	t.Run("float32 series creation and operations", func(t *testing.T) {
+		values := []float32{1.1, -2.2, 3.3, -4.4, 5.5}
+		series, err := NewSafe("test_float32", values, mem)
+		require.NoError(t, err)
+		defer series.Release()
+
+		// Test basic properties
+		assert.Equal(t, "test_float32", series.Name())
+		assert.Equal(t, 5, series.Len())
+		assert.Equal(t, arrow.PrimitiveTypes.Float32, series.DataType())
+
+		// Test value retrieval
+		retrievedValues, err := series.ValuesSafe()
+		require.NoError(t, err)
+		assert.Equal(t, values, retrievedValues)
+
+		// Test individual value access
+		val := series.Value(0)
+		assert.Equal(t, float32(1.1), val)
+
+		val = series.Value(1)
+		assert.Equal(t, float32(-2.2), val)
+	})
 }

--- a/internal/series/new_types_test.go
+++ b/internal/series/new_types_test.go
@@ -1,0 +1,124 @@
+package series
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow"
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewIntegerTypes tests the additional integer types mentioned in Issue #20
+func TestNewIntegerTypes(t *testing.T) {
+	mem := memory.NewGoAllocator()
+
+	t.Run("int16 series creation and operations", func(t *testing.T) {
+		values := []int16{1, -2, 3, -4, 5}
+		series, err := NewSafe("test_int16", values, mem)
+		require.NoError(t, err)
+		defer series.Release()
+
+		// Test basic properties
+		assert.Equal(t, "test_int16", series.Name())
+		assert.Equal(t, 5, series.Len())
+		assert.Equal(t, arrow.PrimitiveTypes.Int16, series.DataType())
+
+		// Test value retrieval
+		retrievedValues, err := series.ValuesSafe()
+		require.NoError(t, err)
+		assert.Equal(t, values, retrievedValues)
+
+		// Test individual value access
+		val := series.Value(0)
+		assert.Equal(t, int16(1), val)
+
+		val = series.Value(1)
+		assert.Equal(t, int16(-2), val)
+	})
+
+	t.Run("int8 series creation and operations", func(t *testing.T) {
+		values := []int8{1, -2, 3, -4, 5}
+		series, err := NewSafe("test_int8", values, mem)
+		require.NoError(t, err)
+		defer series.Release()
+
+		// Test basic properties
+		assert.Equal(t, "test_int8", series.Name())
+		assert.Equal(t, 5, series.Len())
+		assert.Equal(t, arrow.PrimitiveTypes.Int8, series.DataType())
+
+		// Test value retrieval
+		retrievedValues, err := series.ValuesSafe()
+		require.NoError(t, err)
+		assert.Equal(t, values, retrievedValues)
+	})
+
+	t.Run("uint64 series creation and operations", func(t *testing.T) {
+		values := []uint64{1, 2, 3, 4, 5}
+		series, err := NewSafe("test_uint64", values, mem)
+		require.NoError(t, err)
+		defer series.Release()
+
+		// Test basic properties
+		assert.Equal(t, "test_uint64", series.Name())
+		assert.Equal(t, 5, series.Len())
+		assert.Equal(t, arrow.PrimitiveTypes.Uint64, series.DataType())
+
+		// Test value retrieval
+		retrievedValues, err := series.ValuesSafe()
+		require.NoError(t, err)
+		assert.Equal(t, values, retrievedValues)
+	})
+
+	t.Run("uint32 series creation and operations", func(t *testing.T) {
+		values := []uint32{1, 2, 3, 4, 5}
+		series, err := NewSafe("test_uint32", values, mem)
+		require.NoError(t, err)
+		defer series.Release()
+
+		// Test basic properties
+		assert.Equal(t, "test_uint32", series.Name())
+		assert.Equal(t, 5, series.Len())
+		assert.Equal(t, arrow.PrimitiveTypes.Uint32, series.DataType())
+
+		// Test value retrieval
+		retrievedValues, err := series.ValuesSafe()
+		require.NoError(t, err)
+		assert.Equal(t, values, retrievedValues)
+	})
+
+	t.Run("uint16 series creation and operations", func(t *testing.T) {
+		values := []uint16{1, 2, 3, 4, 5}
+		series, err := NewSafe("test_uint16", values, mem)
+		require.NoError(t, err)
+		defer series.Release()
+
+		// Test basic properties
+		assert.Equal(t, "test_uint16", series.Name())
+		assert.Equal(t, 5, series.Len())
+		assert.Equal(t, arrow.PrimitiveTypes.Uint16, series.DataType())
+
+		// Test value retrieval
+		retrievedValues, err := series.ValuesSafe()
+		require.NoError(t, err)
+		assert.Equal(t, values, retrievedValues)
+	})
+
+	t.Run("uint8 series creation and operations", func(t *testing.T) {
+		values := []uint8{1, 2, 3, 4, 5}
+		series, err := NewSafe("test_uint8", values, mem)
+		require.NoError(t, err)
+		defer series.Release()
+
+		// Test basic properties
+		assert.Equal(t, "test_uint8", series.Name())
+		assert.Equal(t, 5, series.Len())
+		assert.Equal(t, arrow.PrimitiveTypes.Uint8, series.DataType())
+
+		// Test value retrieval
+		retrievedValues, err := series.ValuesSafe()
+		require.NoError(t, err)
+		assert.Equal(t, values, retrievedValues)
+	})
+}

--- a/internal/series/series.go
+++ b/internal/series/series.go
@@ -266,50 +266,43 @@ func (s *Series[T]) Values() []T {
 
 	switch arr := s.array.(type) {
 	case *array.String:
-		if any(result).([]string) != nil {
-			values := any(result).([]string)
+		if values, ok := any(result).([]string); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Int64:
-		if any(result).([]int64) != nil {
-			values := any(result).([]int64)
+		if values, ok := any(result).([]int64); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Int32:
-		if any(result).([]int32) != nil {
-			values := any(result).([]int32)
+		if values, ok := any(result).([]int32); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Float64:
-		if any(result).([]float64) != nil {
-			values := any(result).([]float64)
+		if values, ok := any(result).([]float64); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Float32:
-		if any(result).([]float32) != nil {
-			values := any(result).([]float32)
+		if values, ok := any(result).([]float32); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Boolean:
-		if any(result).([]bool) != nil {
-			values := any(result).([]bool)
+		if values, ok := any(result).([]bool); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Timestamp:
-		if any(result).([]time.Time) != nil {
-			values := any(result).([]time.Time)
+		if values, ok := any(result).([]time.Time); ok {
 			for i := 0; i < arr.Len(); i++ {
 				// Convert Arrow timestamp (nanoseconds since Unix epoch) back to time.Time in UTC
 				timestamp := arr.Value(i)
@@ -318,43 +311,37 @@ func (s *Series[T]) Values() []T {
 			}
 		}
 	case *array.Int16:
-		if any(result).([]int16) != nil {
-			values := any(result).([]int16)
+		if values, ok := any(result).([]int16); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Int8:
-		if any(result).([]int8) != nil {
-			values := any(result).([]int8)
+		if values, ok := any(result).([]int8); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Uint64:
-		if any(result).([]uint64) != nil {
-			values := any(result).([]uint64)
+		if values, ok := any(result).([]uint64); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Uint32:
-		if any(result).([]uint32) != nil {
-			values := any(result).([]uint32)
+		if values, ok := any(result).([]uint32); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Uint16:
-		if any(result).([]uint16) != nil {
-			values := any(result).([]uint16)
+		if values, ok := any(result).([]uint16); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Uint8:
-		if any(result).([]uint8) != nil {
-			values := any(result).([]uint8)
+		if values, ok := any(result).([]uint8); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
@@ -373,50 +360,43 @@ func (s *Series[T]) ValuesSafe() ([]T, error) {
 
 	switch arr := s.array.(type) {
 	case *array.String:
-		if any(result).([]string) != nil {
-			values := any(result).([]string)
+		if values, ok := any(result).([]string); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Int64:
-		if any(result).([]int64) != nil {
-			values := any(result).([]int64)
+		if values, ok := any(result).([]int64); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Int32:
-		if any(result).([]int32) != nil {
-			values := any(result).([]int32)
+		if values, ok := any(result).([]int32); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Float64:
-		if any(result).([]float64) != nil {
-			values := any(result).([]float64)
+		if values, ok := any(result).([]float64); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Float32:
-		if any(result).([]float32) != nil {
-			values := any(result).([]float32)
+		if values, ok := any(result).([]float32); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Boolean:
-		if any(result).([]bool) != nil {
-			values := any(result).([]bool)
+		if values, ok := any(result).([]bool); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Timestamp:
-		if any(result).([]time.Time) != nil {
-			values := any(result).([]time.Time)
+		if values, ok := any(result).([]time.Time); ok {
 			for i := 0; i < arr.Len(); i++ {
 				// Convert Arrow timestamp (nanoseconds since Unix epoch) back to time.Time in UTC
 				timestamp := arr.Value(i)
@@ -425,43 +405,37 @@ func (s *Series[T]) ValuesSafe() ([]T, error) {
 			}
 		}
 	case *array.Int16:
-		if any(result).([]int16) != nil {
-			values := any(result).([]int16)
+		if values, ok := any(result).([]int16); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Int8:
-		if any(result).([]int8) != nil {
-			values := any(result).([]int8)
+		if values, ok := any(result).([]int8); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Uint64:
-		if any(result).([]uint64) != nil {
-			values := any(result).([]uint64)
+		if values, ok := any(result).([]uint64); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Uint32:
-		if any(result).([]uint32) != nil {
-			values := any(result).([]uint32)
+		if values, ok := any(result).([]uint32); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Uint16:
-		if any(result).([]uint16) != nil {
-			values := any(result).([]uint16)
+		if values, ok := any(result).([]uint16); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}
 		}
 	case *array.Uint8:
-		if any(result).([]uint8) != nil {
-			values := any(result).([]uint8)
+		if values, ok := any(result).([]uint8); ok {
 			for i := 0; i < arr.Len(); i++ {
 				values[i] = arr.Value(i)
 			}

--- a/internal/series/series.go
+++ b/internal/series/series.go
@@ -84,6 +84,48 @@ func New[T any](name string, values []T, mem memory.Allocator) *Series[T] {
 			builder.Append(timestamp)
 		}
 		arr = builder.NewArray()
+	case []int16:
+		builder := array.NewInt16Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []int8:
+		builder := array.NewInt8Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []uint64:
+		builder := array.NewUint64Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []uint32:
+		builder := array.NewUint32Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []uint16:
+		builder := array.NewUint16Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []uint8:
+		builder := array.NewUint8Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
 	default:
 		panic(fmt.Sprintf("unsupported type: %T", values))
 	}
@@ -154,6 +196,48 @@ func NewSafe[T any](name string, values []T, mem memory.Allocator) (*Series[T], 
 			// Convert time.Time to nanoseconds since Unix epoch (in UTC)
 			timestamp := arrow.Timestamp(val.UTC().UnixNano())
 			builder.Append(timestamp)
+		}
+		arr = builder.NewArray()
+	case []int16:
+		builder := array.NewInt16Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []int8:
+		builder := array.NewInt8Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []uint64:
+		builder := array.NewUint64Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []uint32:
+		builder := array.NewUint32Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []uint16:
+		builder := array.NewUint16Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
+		}
+		arr = builder.NewArray()
+	case []uint8:
+		builder := array.NewUint8Builder(mem)
+		defer builder.Release()
+		for _, val := range v {
+			builder.Append(val)
 		}
 		arr = builder.NewArray()
 	default:
@@ -233,6 +317,48 @@ func (s *Series[T]) Values() []T {
 				values[i] = time.Unix(nanos/nanosPerSecond, nanos%nanosPerSecond).UTC()
 			}
 		}
+	case *array.Int16:
+		if any(result).([]int16) != nil {
+			values := any(result).([]int16)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Int8:
+		if any(result).([]int8) != nil {
+			values := any(result).([]int8)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Uint64:
+		if any(result).([]uint64) != nil {
+			values := any(result).([]uint64)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Uint32:
+		if any(result).([]uint32) != nil {
+			values := any(result).([]uint32)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Uint16:
+		if any(result).([]uint16) != nil {
+			values := any(result).([]uint16)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Uint8:
+		if any(result).([]uint8) != nil {
+			values := any(result).([]uint8)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
 	default:
 		panic(fmt.Sprintf("unsupported array type: %T", arr))
 	}
@@ -298,6 +424,48 @@ func (s *Series[T]) ValuesSafe() ([]T, error) {
 				values[i] = time.Unix(nanos/nanosPerSecond, nanos%nanosPerSecond).UTC()
 			}
 		}
+	case *array.Int16:
+		if any(result).([]int16) != nil {
+			values := any(result).([]int16)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Int8:
+		if any(result).([]int8) != nil {
+			values := any(result).([]int8)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Uint64:
+		if any(result).([]uint64) != nil {
+			values := any(result).([]uint64)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Uint32:
+		if any(result).([]uint32) != nil {
+			values := any(result).([]uint32)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Uint16:
+		if any(result).([]uint16) != nil {
+			values := any(result).([]uint16)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
+	case *array.Uint8:
+		if any(result).([]uint8) != nil {
+			values := any(result).([]uint8)
+			for i := 0; i < arr.Len(); i++ {
+				values[i] = arr.Value(i)
+			}
+		}
 	default:
 		return nil, errors.NewUnsupportedTypeError("values extraction", fmt.Sprintf("%T", arr))
 	}
@@ -344,6 +512,30 @@ func (s *Series[T]) Value(index int) T {
 			timestamp := arr.Value(index)
 			nanos := int64(timestamp)
 			*v = time.Unix(nanos/nanosPerSecond, nanos%nanosPerSecond).UTC()
+		}
+	case *array.Int16:
+		if v, ok := any(&result).(*int16); ok {
+			*v = arr.Value(index)
+		}
+	case *array.Int8:
+		if v, ok := any(&result).(*int8); ok {
+			*v = arr.Value(index)
+		}
+	case *array.Uint64:
+		if v, ok := any(&result).(*uint64); ok {
+			*v = arr.Value(index)
+		}
+	case *array.Uint32:
+		if v, ok := any(&result).(*uint32); ok {
+			*v = arr.Value(index)
+		}
+	case *array.Uint16:
+		if v, ok := any(&result).(*uint16); ok {
+			*v = arr.Value(index)
+		}
+	case *array.Uint8:
+		if v, ok := any(&result).(*uint8); ok {
+			*v = arr.Value(index)
 		}
 	}
 


### PR DESCRIPTION
## Summary

This PR implements support for additional integer types in the Series type system, addressing part of Issue #20 - Expand Series Type System.

### Changes Made

- **New integer types supported:** `int16`, `int8`, `uint64`, `uint32`, `uint16`, `uint8`
- **Complete Series integration:** All new types work with Series creation, value extraction, and type safety
- **DataFrame compatibility:** Full support for DataFrame operations including slicing, column access, and data manipulation
- **Comprehensive test coverage:** Added extensive tests for all new integer types in both Series and DataFrame contexts
- **Memory management:** Proper Arrow memory allocator integration for all new types

### Technical Details

**Series Implementation:**
- Extended `New()` and `NewSafe()` functions with type cases for all new integer types
- Added support in `Values()`, `ValuesSafe()`, and `Value()` methods for value extraction
- Maintained type safety with compile-time type checking

**DataFrame Implementation:**
- Added `createSlicedXXXSeries()` functions for all new integer types
- Extended `createSlicedSeriesFromArray()` to handle new Arrow array types
- Ensured proper slicing and column operations work seamlessly

**Testing:**
- Created comprehensive test suites for both Series and DataFrame operations
- Tests cover creation, value retrieval, slicing, and type validation
- All existing tests continue to pass, ensuring backward compatibility

### Test Results

- ✅ All Series tests pass
- ✅ All DataFrame tests pass  
- ✅ All existing tests continue to pass
- ✅ Linter and code quality checks pass
- ✅ Build successful

### Impact

This implementation provides:
- **Memory efficiency:** Smaller integer types use less memory
- **Type safety:** Compile-time type checking prevents runtime errors
- **Performance:** Native Arrow integration for optimal performance
- **Compatibility:** Full integration with existing DataFrame operations

Closes part of #20

🤖 Generated with [Claude Code](https://claude.ai/code)