### PR TITLE
fix(dataframe): resolve GroupBy aggregation group assignment bug

### DIFF
--- a/gorilla_test.go
+++ b/gorilla_test.go
@@ -547,9 +547,6 @@ func TestLazyFrame_Join(t *testing.T) {
 }
 
 func TestExpression_Mean(t *testing.T) {
-	t.Skip("KNOWN BUG: Mean aggregation assigns group values to wrong departments. " +
-		"Values are swapped between Eng and Sales. Pre-existing bug in GroupBy aggregation.")
-
 	mem := memory.NewGoAllocator()
 
 	departments := gorilla.NewSeries("dept", []string{"Eng", "Sales", "Eng", "Sales"}, mem)
@@ -604,9 +601,6 @@ func TestExpression_Mean(t *testing.T) {
 }
 
 func TestExpression_Min(t *testing.T) {
-	t.Skip("KNOWN BUG: Min aggregation assigns group values to wrong departments. " +
-		"Sales should get 80.0 but gets 100.0. Pre-existing bug in GroupBy aggregation.")
-
 	mem := memory.NewGoAllocator()
 
 	departments := gorilla.NewSeries("dept", []string{"Eng", "Sales", "Eng", "Sales"}, mem)
@@ -642,9 +636,6 @@ func TestExpression_Min(t *testing.T) {
 }
 
 func TestExpression_Max(t *testing.T) {
-	t.Skip("KNOWN BUG: Max aggregation assigns group values to wrong departments. " +
-		"Pre-existing bug in GroupBy aggregation.")
-
 	mem := memory.NewGoAllocator()
 
 	departments := gorilla.NewSeries("dept", []string{"Eng", "Sales", "Eng", "Sales"}, mem)

--- a/internal/dataframe/dataframe.go
+++ b/internal/dataframe/dataframe.go
@@ -835,8 +835,16 @@ func (gb *GroupBy) extractGroupColumnValues(series ISeries) []string {
 	originalArray := series.Array()
 	defer originalArray.Release()
 
+	// Get sorted group keys to ensure deterministic order
+	var groupKeys []string
+	for key := range gb.groups {
+		groupKeys = append(groupKeys, key)
+	}
+	sort.Strings(groupKeys)
+
 	// Extract first value from each group (all values in a group are the same)
-	for _, indices := range gb.groups {
+	for _, key := range groupKeys {
+		indices := gb.groups[key]
 		if len(indices) > 0 {
 			rowIdx := indices[0]
 			if rowIdx < originalArray.Len() && !originalArray.IsNull(rowIdx) {
@@ -867,7 +875,15 @@ func (gb *GroupBy) performAggregation(series ISeries, agg *expr.AggregationExpr)
 	originalArray := series.Array()
 	defer originalArray.Release()
 
-	for _, indices := range gb.groups {
+	// Get sorted group keys to ensure deterministic order
+	var groupKeys []string
+	for key := range gb.groups {
+		groupKeys = append(groupKeys, key)
+	}
+	sort.Strings(groupKeys)
+
+	for _, key := range groupKeys {
+		indices := gb.groups[key]
 		result := gb.aggregateGroup(originalArray, indices, agg.AggType())
 		results = append(results, result)
 	}


### PR DESCRIPTION
## Summary

Fixes issue #98 where GroupBy aggregation results were assigned to wrong groups due to non-deterministic map iteration in Go. This caused values to be swapped between departments (e.g., Engineering getting Sales values and vice versa).

## Root Cause

The bug was in the `extractGroupColumnValues()` and `performAggregation()` methods in `internal/dataframe/dataframe.go`. Both methods were iterating over the `gb.groups` map without ensuring consistent ordering, leading to:
- Group values being extracted in random order
- Aggregation results being calculated in random order
- Misalignment between group identifiers and their corresponding aggregated values

## Solution

- **Fixed both methods** to sort group keys before iteration using `sort.Strings(groupKeys)`
- This ensures deterministic order, preventing group value swapping
- **Re-enabled all previously skipped tests** (`TestExpression_Mean`, `TestExpression_Min`, `TestExpression_Max`)

## Changes

- `internal/dataframe/dataframe.go`: Add sorted group key iteration to ensure deterministic order
- `gorilla_test.go`: Remove skip statements from tests that were failing due to the bug

## Test Results

All tests now pass with correct group value assignments:

- **Mean aggregation**: 
  - Eng: 110.0 (average of 100 and 120) ✅
  - Sales: 85.0 (average of 80 and 90) ✅
- **Min aggregation**: Sales correctly gets 80.0 ✅
- **Max aggregation**: Eng correctly gets 120.0 ✅

## Verification

- [x] All tests pass
- [x] Pre-commit hooks (gofmt, golangci-lint, govet) pass
- [x] Fix verified with comprehensive test cases
- [x] No breaking changes to public API

Closes #98

🤖 Generated with [Claude Code](https://claude.ai/code)