### PR TITLE
fix: resolve #140 - re-enable SQL execution functionality

### DIFF
--- a/gorilla.go
+++ b/gorilla.go
@@ -74,8 +74,7 @@ import (
 	"github.com/paveg/gorilla/internal/dataframe"
 	"github.com/paveg/gorilla/internal/expr"
 	"github.com/paveg/gorilla/internal/series"
-	// TODO: Enable SQL import after fixing compilation errors
-	// "github.com/paveg/gorilla/internal/sql"
+	"github.com/paveg/gorilla/internal/sql"
 	"github.com/paveg/gorilla/internal/version"
 )
 
@@ -798,10 +797,9 @@ func ExampleDataFrameJoin() {
 //		panic(err)
 //	}
 //	defer result.Release()
-// TODO: Enable SQL after fixing compilation errors
-// type SQLExecutor struct {
-//	executor *sql.SQLExecutor
-// }
+type SQLExecutor struct {
+	executor *sql.SQLExecutor
+}
 
 // NewSQLExecutor creates a new SQL executor for DataFrame queries.
 //
@@ -823,12 +821,11 @@ func ExampleDataFrameJoin() {
 //	// Execute SQL queries
 //	result, err := executor.Execute("SELECT * FROM sales WHERE amount > 1000")
 //	defer result.Release()
-// TODO: Enable SQL after fixing compilation errors
-// func NewSQLExecutor(mem memory.Allocator) *SQLExecutor {
-//	return &SQLExecutor{
-//		executor: sql.NewSQLExecutor(mem),
-//	}
-// }
+func NewSQLExecutor(mem memory.Allocator) *SQLExecutor {
+	return &SQLExecutor{
+		executor: sql.NewSQLExecutor(mem),
+	}
+}
 
 // RegisterTable registers a DataFrame with a table name for SQL queries.
 //
@@ -846,8 +843,6 @@ func ExampleDataFrameJoin() {
 //
 //	// Now can use in SQL
 //	result, err := executor.Execute("SELECT * FROM employees WHERE dept_id IN (SELECT id FROM departments)")
-// TODO: Enable SQL after fixing compilation errors
-/*
 func (se *SQLExecutor) RegisterTable(name string, df *DataFrame) {
 	se.executor.RegisterTable(name, df.df)
 }
@@ -1049,4 +1044,3 @@ func ExampleSQLExecutor() {
 
 	fmt.Println(result)
 }
-*/

--- a/sql_integration_test.go
+++ b/sql_integration_test.go
@@ -1,0 +1,109 @@
+package gorilla
+
+import (
+	"testing"
+
+	"github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSQLExecutorIntegration tests that SQL functionality is available through the public API
+func TestSQLExecutorIntegration(t *testing.T) {
+	mem := memory.NewGoAllocator()
+
+	// Create test data
+	names := NewSeries("name", []string{"Alice", "Bob", "Charlie"}, mem)
+	ages := NewSeries("age", []int64{25, 30, 35}, mem)
+	defer names.Release()
+	defer ages.Release()
+
+	df := NewDataFrame(names, ages)
+	defer df.Release()
+
+	// Test that NewSQLExecutor function exists and works
+	executor := NewSQLExecutor(mem)
+	require.NotNil(t, executor, "NewSQLExecutor should return a valid executor")
+
+	// Test that RegisterTable method works
+	executor.RegisterTable("employees", df)
+
+	// Test basic SQL query execution
+	result, err := executor.Execute("SELECT name FROM employees WHERE age > 30")
+	require.NoError(t, err, "SQL query execution should not fail")
+	require.NotNil(t, result, "SQL query should return a result")
+	defer result.Release()
+
+	// Verify result content
+	assert.Equal(t, 1, result.Width(), "Result should have 1 column")
+	assert.Equal(t, 1, result.Len(), "Result should have 1 row (Charlie)")
+
+	nameCol, exists := result.Column("name")
+	require.True(t, exists, "Result should have 'name' column")
+	assert.Equal(t, "Charlie", nameCol.GetAsString(0), "Result should contain Charlie")
+}
+
+// TestSQLExecutorValidation tests query validation functionality
+func TestSQLExecutorValidation(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	executor := NewSQLExecutor(mem)
+
+	// Register a test table for validation
+	names := NewSeries("name", []string{"Alice"}, mem)
+	defer names.Release()
+	df := NewDataFrame(names)
+	defer df.Release()
+	executor.RegisterTable("test_table", df)
+
+	// Test validation of valid query
+	err := executor.ValidateQuery("SELECT * FROM test_table")
+	assert.NoError(t, err, "Valid SQL query should pass validation")
+
+	// Test validation of invalid query
+	err = executor.ValidateQuery("SELECT * FROM")
+	assert.Error(t, err, "Invalid SQL query should fail validation")
+}
+
+// TestSQLExecutorExplain tests query explanation functionality
+func TestSQLExecutorExplain(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	executor := NewSQLExecutor(mem)
+
+	// Create test data and register table
+	names := NewSeries("name", []string{"Alice", "Bob"}, mem)
+	defer names.Release()
+	df := NewDataFrame(names)
+	defer df.Release()
+	executor.RegisterTable("test", df)
+
+	// Test explain functionality
+	plan, err := executor.Explain("SELECT name FROM test WHERE name = 'Alice'")
+	require.NoError(t, err, "EXPLAIN should work for valid queries")
+	assert.NotEmpty(t, plan, "EXPLAIN should return a non-empty plan")
+}
+
+// TestSQLExecutorTableManagement tests table registration and management
+func TestSQLExecutorTableManagement(t *testing.T) {
+	mem := memory.NewGoAllocator()
+	executor := NewSQLExecutor(mem)
+
+	// Test initial state
+	tables := executor.GetRegisteredTables()
+	assert.Empty(t, tables, "Executor should start with no registered tables")
+
+	// Register a table
+	names := NewSeries("name", []string{"Alice"}, mem)
+	defer names.Release()
+	df := NewDataFrame(names)
+	defer df.Release()
+	executor.RegisterTable("test_table", df)
+
+	// Verify table is registered
+	tables = executor.GetRegisteredTables()
+	assert.Contains(t, tables, "test_table", "Table should be registered")
+
+	// Clear tables
+	executor.ClearTables()
+	tables = executor.GetRegisteredTables()
+	assert.Empty(t, tables, "All tables should be cleared")
+}


### PR DESCRIPTION
This PR addresses issue #140 by re-enabling SQL execution functionality that was previously disabled due to compilation errors.

## Summary

- ✅ Re-enabled SQL package import in `gorilla.go`
- ✅ Exposed `SQLExecutor` and all SQL methods through public API
- ✅ Added comprehensive integration tests for SQL functionality
- ✅ Verified end-to-end SQL query execution works properly

## Root Cause

The SQL functionality was already working correctly but was commented out in the public API due to perceived compilation errors. Investigation revealed no actual compilation issues in the `internal/sql` package.

## Changes Made

### 1. Re-enabled SQL Import
```go
// Before (commented out)
// "github.com/paveg/gorilla/internal/sql"

// After (enabled)
"github.com/paveg/gorilla/internal/sql"
```

### 2. Exposed SQL Functionality
- Uncommented `SQLExecutor` struct and all methods
- Made `NewSQLExecutor()` function available
- Exposed all SQL methods: `Execute()`, `RegisterTable()`, `ValidateQuery()`, `Explain()`, etc.

### 3. Added Integration Tests
Created comprehensive test suite (`sql_integration_test.go`) covering:
- Basic SQL query execution
- Table registration and management  
- Query validation
- Query explanation functionality
- Error handling

## Usage Example

Users can now execute SQL queries against DataFrames:

```go
mem := memory.NewGoAllocator()
executor := gorilla.NewSQLExecutor(mem)

// Register DataFrame as table
executor.RegisterTable("employees", employeesDF)

// Execute SQL queries
result, err := executor.Execute(`
    SELECT department, AVG(salary) as avg_salary, COUNT(*) as employee_count
    FROM employees
    WHERE active = true
    GROUP BY department
    ORDER BY avg_salary DESC
`)
defer result.Release()
```

## Test Results

- ✅ All existing tests continue to pass
- ✅ New SQL integration tests pass
- ✅ Linting and formatting checks pass
- ✅ Full compilation succeeds

## Breaking Changes

None. This only adds previously unavailable functionality back to the public API.

Closes #140

🤖 Generated with [Claude Code](https://claude.ai/code)