### PR TITLE
refactor: complete interface{} to any modernization

### DIFF
--- a/internal/io/json.go
+++ b/internal/io/json.go
@@ -109,7 +109,7 @@ func (r *JSONReader) recordsToDataFrame(records []map[string]any) (*dataframe.Da
 	// Extract data by column
 	columnData := make(map[string][]any)
 	for _, col := range columns {
-		columnData[col] = make([]interface{}, len(records))
+		columnData[col] = make([]any, len(records))
 		for i, record := range records {
 			if value, exists := record[col]; exists {
 				columnData[col][i] = value
@@ -135,7 +135,7 @@ func (r *JSONReader) recordsToDataFrame(records []map[string]any) (*dataframe.Da
 	return dataframe.New(seriesList...), nil
 }
 
-// createSeriesFromData creates a Series from interface{} data with type inference.
+// createSeriesFromData creates a Series from any data with type inference.
 func (r *JSONReader) createSeriesFromData(name string, data []any) (dataframe.ISeries, error) {
 	if !r.options.TypeInference {
 		// Convert all to strings if type inference is disabled
@@ -288,7 +288,7 @@ func (r *JSONReader) selectBestType(flags dataTypeFlags) string {
 	return ArrowTypeString
 }
 
-// createInt64Series creates an int64 series from interface{} data.
+// createInt64Series creates an int64 series from any data.
 func (r *JSONReader) createInt64Series(name string, data []any) (dataframe.ISeries, error) {
 	values := make([]int64, len(data))
 	for i, v := range data {
@@ -297,7 +297,7 @@ func (r *JSONReader) createInt64Series(name string, data []any) (dataframe.ISeri
 	return series.NewSafe(name, values, r.mem)
 }
 
-// createFloat64Series creates a float64 series from interface{} data.
+// createFloat64Series creates a float64 series from any data.
 func (r *JSONReader) createFloat64Series(name string, data []any) (dataframe.ISeries, error) {
 	values := make([]float64, len(data))
 	for i, v := range data {
@@ -306,7 +306,7 @@ func (r *JSONReader) createFloat64Series(name string, data []any) (dataframe.ISe
 	return series.NewSafe(name, values, r.mem)
 }
 
-// createBoolSeries creates a bool series from interface{} data.
+// createBoolSeries creates a bool series from any data.
 func (r *JSONReader) createBoolSeries(name string, data []any) (dataframe.ISeries, error) {
 	values := make([]bool, len(data))
 	for i, v := range data {
@@ -315,7 +315,7 @@ func (r *JSONReader) createBoolSeries(name string, data []any) (dataframe.ISerie
 	return series.NewSafe(name, values, r.mem)
 }
 
-// createStringSeries creates a string series from interface{} data.
+// createStringSeries creates a string series from any data.
 func (r *JSONReader) createStringSeries(name string, data []any) (dataframe.ISeries, error) {
 	values := make([]string, len(data))
 	for i, v := range data {


### PR DESCRIPTION
## Summary

This PR completes the modernization of the JSON I/O implementation by converting the remaining `interface{}` instances to use the modern `any` type introduced in Go 1.18.

## Changes Made

### 1. Final Interface{} to Any Conversion
- Fixed remaining `interface{}` instances in `json.go`
- Updated array initialization: `make([]interface{}, len)` → `make([]any, len)`
- Modernized function comments to reflect `any` instead of `interface{}`

### 2. Comment Updates
- Updated all function comments to use "any data" instead of "interface{} data"
- Improved consistency across the codebase
- Maintained clear documentation of function purposes

### 3. Code Quality Improvements
- Completed the modernization started in PR #176
- Ensured full consistency throughout the JSON I/O implementation
- All changes maintain backward compatibility

## Testing

- ✅ All existing tests pass
- ✅ No functional changes - purely modernization
- ✅ Full linting compliance with 0 issues
- ✅ Pre-commit hooks pass successfully

## Impact

- **Improved consistency**: Completes the interface{} → any modernization
- **Better readability**: Modern Go idioms throughout the JSON I/O code
- **Zero breaking changes**: All existing functionality preserved
- **Future-ready codebase**: Uses current Go 1.18+ best practices

This PR builds on the work from PR #176 and completes the modernization effort for the JSON I/O implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)